### PR TITLE
Added utility management, price setters, and secure STX withdrawal functions with owner validation and input checks.

### DIFF
--- a/contracts/stx-vesting-nft.clar
+++ b/contracts/stx-vesting-nft.clar
@@ -123,3 +123,52 @@
     )
   )
 )
+
+
+;; Enhanced utility setter
+(define-public (set-level-utility (token-id uint) (level uint) (utility (string-ascii 256)))
+  (begin
+    (asserts! (is-eq tx-sender contract-owner) (err err-owner-only))
+    ;; Check if token exists
+    (asserts! (is-some (map-get? tokens { token-id: token-id })) (err err-invalid-token))
+    ;; Validate utility string is not empty
+    (asserts! (> (len utility) u0) (err err-invalid-params))
+    (ok (map-set token-levels { token-id: token-id, level: level } { utility: utility }))
+  )
+)
+
+
+
+;; Enhanced price setters
+(define-public (set-mint-price (new-price uint))
+  (begin
+    (asserts! (is-eq tx-sender contract-owner) (err err-owner-only))
+    (asserts! (> new-price u0) (err err-invalid-params))
+    (ok (var-set mint-price new-price))
+  )
+)
+
+(define-public (set-level-up-price (new-price uint))
+  (begin
+    (asserts! (is-eq tx-sender contract-owner) (err err-owner-only))
+    (asserts! (> new-price u0) (err err-invalid-params))
+    (ok (var-set level-up-price new-price))
+  )
+)
+
+;; Enhanced STX withdrawal
+(define-public (withdraw-stx (amount uint))
+  (begin
+    (asserts! (is-eq tx-sender contract-owner) (err err-owner-only))
+    (asserts! (> amount u0) (err err-zero-amount))
+
+    (let ((contract-balance (stx-get-balance (as-contract tx-sender))))
+      (asserts! (>= contract-balance amount) (err err-insufficient-funds))
+
+      (match (as-contract (stx-transfer? amount tx-sender contract-owner))
+        success (ok amount)
+        error (err err-insufficient-funds))
+    )
+  )
+)
+


### PR DESCRIPTION
# Pull Request: Added Enhanced Utility Management, Price Setters, and STX Withdrawal Functions

## Description
This pull request introduces new utility, price management, and STX withdrawal features to the `stx-vesting-nft` contract. These additions allow the contract owner to manage the token utilities by level, dynamically set mint and level-up prices, and withdraw STX from the contract’s balance. The code also enforces strict access controls and input validation for secure operations.

## Key Changes

### Set Utility for Token Levels

- A new public function allows the contract owner to assign utility descriptions to specific levels of a token.
- Ensures that the token exists and the utility string is valid.

### Dynamic Mint and Level-up Price Setters

- The contract owner can adjust mint and level-up prices in STX.
- Input validation ensures the prices are positive values.

### STX Withdrawal Functionality

- Allows the contract owner to withdraw STX from the contract’s balance.
- Validates available balance and withdrawal amount to prevent overdrafts.

## Functions and Usage

### 1. Set Utility for Token Levels

Allows the contract owner to assign or update utilities for a specific token and level.

```clarity
(define-public (set-level-utility (token-id uint) (level uint) (utility (string-ascii 256))))
```

**Parameters:**

- `token-id`: ID of the token.
- `level`: Level to assign the utility to.
- `utility`: Utility string (max 256 ASCII chars).

**Errors:**

- `err-owner-only`: Only the contract owner can set utilities.
- `err-invalid-token`: Token must exist.
- `err-invalid-params`: Utility string cannot be empty.

### 2. Set Mint and Level-up Prices

Allows the contract owner to dynamically set the mint price and level-up price.

**Set Mint Price:**

```clarity
(define-public (set-mint-price (new-price uint)))
```

**Parameter:**

- `new-price`: New minting price in STX.

**Set Level-up Price:**

```clarity
(define-public (set-level-up-price (new-price uint)))
```

**Parameter:**

- `new-price`: New level-up price in STX.

**Errors for Both:**

- `err-owner-only`: Only the contract owner can change prices.
- `err-invalid-params`: Prices must be greater than 0.

### 3. STX Withdrawal

Allows the contract owner to withdraw STX from the contract’s balance.

```clarity
(define-public (withdraw-stx (amount uint)))
```

**Parameter:**

- `amount`: Amount of STX to withdraw.

**Errors:**

- `err-owner-only`: Only the contract owner can withdraw STX.
- `err-zero-amount`: Withdrawal amount must be greater than 0.
- `err-insufficient-funds`: Contract balance must cover the withdrawal amount.

## Error Handling

| Error Code | Description                                      |
|------------|--------------------------------------------------|
| u100       | Only the contract owner can perform this action. |
| u102       | Invalid token ID.                                |
| u104       | Invalid parameters provided.                     |
| u105       | Amount cannot be zero.                           |
| u103       | Insufficient STX balance for transaction.        |

## Example Workflow

### Set Level Utility

As the contract owner, set a utility string for token 1 at level 2.

```clarity
(set-level-utility u1 u2 "Access to exclusive content")
```

### Change Mint Price

Update the minting price to 300 STX.

```clarity
(set-mint-price u300000000)
```

### Withdraw STX

Withdraw 50 STX from the contract’s balance.

```clarity
(withdraw-stx u50000000)
```

## Security Features

- **Owner-Only Operations:** Only the contract owner can set prices, utilities, or withdraw STX.
- **Input Validation:** Ensures that prices and withdrawal amounts are positive values.
- **Balance Verification:** Prevents overdrawing the contract by validating the available STX balance.